### PR TITLE
tl_detector: preserve original RGB encoding

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -156,8 +156,7 @@ class TLDetector(object):
             self.prev_light_loc = None
             return TrafficLight.UNKNOWN
 
-        cv_image = self.bridge.imgmsg_to_cv2(self.camera_image)
-        rgb = cv2.cvtColor(cv_image, cv2.COLOR_BGR2RGB)
+        rgb = self.bridge.imgmsg_to_cv2(self.camera_image)
 
         # cv2.imwrite("./data/test/test.{}.jpg".format(self.camera_image.header.seq), rgb)
 


### PR DESCRIPTION
When I ran the tl_detector, it was detecting all the lights as green :(

After some debugging, I noticed you did not pass any arguments to the cvbridge conversion function. 
 Without args, CvBridge does not modify the source data, which is RGB.
 
http://wiki.ros.org/cv_bridge/Tutorials/UsingCvBridgeToConvertBetweenROSImagesAndOpenCVImages

Since RGB is what the detector expects, the cv2.cvtColor is incorrect here.

I noticed you had a commented call to cv2.imsave...this function would expect BGR data.

After removing the cvtColor call, the detections now look correct :) 